### PR TITLE
Set BuildParameterType.PASSWORD type for non-stored password

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildwithparameters/BuildWithParametersAction.java
+++ b/src/main/java/org/jenkinsci/plugins/buildwithparameters/BuildWithParametersAction.java
@@ -52,6 +52,7 @@ public class BuildWithParametersAction<T extends Job<?, ?> & ParameterizedJob> i
 
         for (ParameterDefinition parameterDefinition : getParameterDefinitions()) {
             BuildParameter buildParameter = new BuildParameter(parameterDefinition.getName(), parameterDefinition.getDescription());
+
             if (parameterDefinition.getClass().isAssignableFrom(PasswordParameterDefinition.class)) {
                 buildParameter.setType(BuildParameterType.PASSWORD);
             } else if (parameterDefinition.getClass().isAssignableFrom(BooleanParameterDefinition.class)) {
@@ -64,8 +65,11 @@ public class BuildWithParametersAction<T extends Job<?, ?> & ParameterizedJob> i
             } else if (parameterDefinition.getClass().isAssignableFrom(TextParameterDefinition.class)) {
                 buildParameter.setType(BuildParameterType.TEXT);
             } else {
-                // default to string
-                buildParameter.setType(BuildParameterType.STRING);
+                if (parameterDefinition.getClass().toString().equals("class com.michelin.cio.hudson.plugins.passwordparam.PasswordParameterDefinition")) { // Integration with mask-passwords-plugin
+                    buildParameter.setType(BuildParameterType.PASSWORD);
+                } else { // default to string
+                    buildParameter.setType(BuildParameterType.STRING);
+                }
             }
 
             try {


### PR DESCRIPTION
### Integration with [mask-passwords-plugin](https://github.com/jenkinsci/mask-passwords-plugin), Non-Stored Password Parameter

Set parameter type to **BuildParameterType.PASSWORD** for **Non-Stored Password Parameter**.
On _jenkins_url/job_name/parambuild/?_ **non-stored-password** variable text box was not of _<f:password />_ type. So, I added a new if statement to check if the **parameterDefinition** is a **non-stored password**.

### _Explanation_:
Before my pull request **non-stored password** got **BuildParameterType.STRING** (line 68 before pull request), because **Non-Stored Password Parameter** inherits directly from **hudson.model.ParameterDefinition**, so the **build-with-parameters-plugin** doesn't see **Non-Stored Password Parameter** as a PASSWORD.

If **Non-Stored Password Parameter** starts to inherit from **hudson.model.PasswordParameterDefinition**, the password will be saved on the hard disc (this must not happen).

