### PR TITLE
Prepare for icon removal from core

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/buildwithparameters/BuildWithParametersAction/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildwithparameters/BuildWithParametersAction/index.jelly
@@ -3,7 +3,7 @@
     <l:layout title="${%Build With Parameters}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="../" title="${%Back to Project}"/>
+                <l:task icon="icon-up icon-md" href="../" title="${%Back to Project}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>


### PR DESCRIPTION
Preparation for core removing sunset icons: `https://github.com/jenkinsci/jenkins/pull/5778`

@sugonyak Would be nice if you can also trigger a release after merging this PR.
Thanks in advance!