### PR TITLE
Fix order of evaluation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildwithparameters/BuildParameter.java
+++ b/src/main/java/org/jenkinsci/plugins/buildwithparameters/BuildParameter.java
@@ -41,10 +41,10 @@ public class BuildParameter {
     }
 
     public void setValue(ParameterValue parameterValue) {
-        if (parameterValue instanceof StringParameterValue) {
-            this.value = ((StringParameterValue) parameterValue).getValue();
-        } else if (parameterValue instanceof TextParameterValue) {
+        if (parameterValue instanceof TextParameterValue) {
             this.value = ((TextParameterValue) parameterValue).getValue();
+        } else if (parameterValue instanceof StringParameterValue) {
+            this.value = ((StringParameterValue) parameterValue).getValue();
         } else if (parameterValue instanceof BooleanParameterValue) {
             this.value = String.valueOf(((BooleanParameterValue) parameterValue).getValue());
         } else if (parameterValue instanceof PasswordParameterValue) {


### PR DESCRIPTION
`TextParameterValue` is a subclass of `StringParameterValue` therefore it wont ever hit it's if-branch.


----------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
